### PR TITLE
Update OpenCVClient/OpenCVClientViewController.mm

### DIFF
--- a/OpenCVClient/OpenCVClientViewController.mm
+++ b/OpenCVClient/OpenCVClientViewController.mm
@@ -151,7 +151,7 @@ const int kCannyAperture = 7;
     cv::Mat grayFrame, output;
   
     // Convert captured frame to grayscale
-    cv::cvtColor(_lastFrame, grayFrame, cv::COLOR_RGB2GRAY);
+    cv::cvtColor(_lastFrame, grayFrame, cv::COLOR_BGR2GRAY);
     
     // Perform Canny edge detection using slide values for thresholds
     cv::Canny(grayFrame, output,


### PR DESCRIPTION
*OpenCV uses BGR rather than RGB.  This doesn't matter unless you try to use the color image with the included UIImage imageWithCVMat method.  Maybe that colorspace conversion should be done there (since it assumes RGB)?  I kept getting type issues when I tried to add it to UIImage+OpenCV.mm.
